### PR TITLE
Better Master Process Exit Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ var manager = new ClusterManager({
 
   // Tell it not to kill the master process on an un-handled error
   // (sometimes useful, not recommended)
-  killOnError: false
+  killOnError: false,
+
+  // Perform some action before the master process exits due to an error
+  beforeExit: function() {
+    // ...
+  }
 });
 
 // Start the cluster!
@@ -83,6 +88,7 @@ application.
 To aid such specialized behaviors the `ClusterManager` class was designed to be
 extendable via prototypal inheritance. Furthermore, instances expose the node
 `cluster` directly so additional eventing can easily be added.
+
 
 **Example: Adding additional cluster event listeners**
 ```js

--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ var manager = new ClusterManager({
   killOnError: false,
 
   // Perform some action before the master process exits due to an error
-  beforeExit: function() {
-    // ...
+  beforeExit: function(err, done) {
+    // Do what you need to before the process is killed...
+
+    // Then call the `done` function
+    done();
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cluster-man",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Extendable and easy-to-use node cluster management.",
   "main": "index.js",
   "scripts": {

--- a/test/methods.js
+++ b/test/methods.js
@@ -135,6 +135,15 @@ describe('cluster-man', function () {
         expect(manager.options.killOnError).to.be.false();
         done();
       });
+
+      it('should not allow non-function beforeExit option', function(done) {
+        var manager = new ClusterManager({
+          worker: noop,
+          beforeExit: 'not a function'
+        });
+        expect(manager.options.beforeExit).to.equal(noop);
+        done();
+      });
     }); // end 'constructor'
 
     describe('_addLogger', function () {
@@ -227,6 +236,49 @@ describe('cluster-man', function () {
         done();
       });
     }); // end '_startMaster'
+
+    describe('_exitMaster', function() {
+      beforeEach(function (done) {
+        sinon.stub(process, 'exit');
+        done();
+      });
+
+      afterEach(function (done) {
+        process.exit.restore();
+        done();
+      });
+
+      it('should execute the `beforeExit` callback', function(done) {
+        var manager = new ClusterManager({
+          worker: noop,
+          beforeExit: function() {
+            return 'beforeExit';
+          }
+        });
+        var spy = sinon.spy(manager.options, 'beforeExit');
+        var err = new Error('Error');
+        manager._exitMaster(err);
+        expect(spy.calledOnce).to.be.true();
+        expect(spy.calledWith(err)).to.be.true();
+        done();
+      });
+
+      it('should exit the process with code 1 when given an error', function(done) {
+        var manager = new ClusterManager(noop);
+        manager._exitMaster(new Error('error'));
+        expect(process.exit.calledOnce).to.be.true();
+        expect(process.exit.calledWith(1)).to.be.true();
+        done();
+      });
+
+      it('should exit the process with code 0 when not given an error', function (done) {
+        var manager = new ClusterManager(noop);
+        manager._exitMaster();
+        expect(process.exit.calledOnce).to.be.true();
+        expect(process.exit.calledWith(0)).to.be.true();
+        done();
+      });
+    }); // end '_exitMaster'
 
     describe('_startWorker', function () {
       it('should call the worker callback', function (done) {

--- a/test/methods.js
+++ b/test/methods.js
@@ -251,8 +251,8 @@ describe('cluster-man', function () {
       it('should execute the `beforeExit` callback', function(done) {
         var manager = new ClusterManager({
           worker: noop,
-          beforeExit: function() {
-            return 'beforeExit';
+          beforeExit: function(err, done) {
+            done();
           }
         });
         var spy = sinon.spy(manager.options, 'beforeExit');


### PR DESCRIPTION
This adds a new option named `beforeExit` to the `ClusterManager` constructor. This method will be executed before the master process is forcibly exited. Additionally, the manager will automatically exit if all of the worker processes die.