### PR TITLE
Housekeeping Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
   - '4.2'
   - '5'
 matrix:
-  allowed_failures:
-  - '5'
+  allow_failures:
+  - node_js: '5'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+  - '0.10'
+  - '0.12'
+  - '4.2'
+  - '5'
+matrix:
+  allowed_failures:
+  - '5'
+sudo: false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('loadenv')('cluster-man')
+require('loadenv')()
 
 var cluster = require('cluster')
 var debug = require('debug')

--- a/index.js
+++ b/index.js
@@ -176,7 +176,10 @@ ClusterManager.prototype._startMaster = function () {
 
   // Execute master callback from options
   masterDomain.run(function () {
-    self.options.master(this)
+    // To support any sync throws, wrap in `process.nextTick`.
+    process.nextTick(function () {
+      self.options.master(this)
+    }.bind(this))
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Extendable and easy-to-use node cluster management.",
   "main": "index.js",
   "scripts": {
-    "test": "jshint index.js && NODE_ENV=test lab -v -c test/*",
+    "format": "standard --format --verbose",
+    "lint": "standard --verbose",
+    "test": "npm run lint && NODE_ENV=test lab -v -t 100 test/*",
     "doc": "jsdoc index.js -d doc; open -a 'Google Chrome' doc/index.html"
   },
   "repository": {
@@ -22,19 +24,15 @@
     "url": "https://github.com/Runnable/cluster-man/issues"
   },
   "homepage": "https://github.com/Runnable/cluster-man",
-  "jshintConfig": {
-    "node": true,
-    "curly": true
-  },
   "devDependencies": {
     "code": "^1.4.0",
     "jsdoc": "^3.3.0-beta3",
-    "jshint": "^2.6.3",
     "lab": "^5.5.1",
-    "sinon": "^1.14.1"
+    "sinon": "^1.14.1",
+    "standard": "^5.4.1"
   },
   "dependencies": {
-    "101": "^0.16.1",
+    "101": "^1.2.0",
     "debug": "^2.1.3",
     "loadenv": "^1.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   "dependencies": {
     "101": "^1.2.0",
     "debug": "^2.1.3",
-    "loadenv": "^1.0.3"
+    "loadenv": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "format": "standard --format --verbose",
     "lint": "standard --verbose",
-    "test": "npm run lint && NODE_ENV=test lab -v -t 100 test/*",
+    "test": "npm run lint && NODE_ENV=test mocha",
     "doc": "jsdoc index.js -d doc; open -a 'Google Chrome' doc/index.html"
   },
   "repository": {
@@ -24,10 +24,20 @@
     "url": "https://github.com/Runnable/cluster-man/issues"
   },
   "homepage": "https://github.com/Runnable/cluster-man",
+  "standard": {
+    "globals": [
+      "describe",
+      "it",
+      "before",
+      "after",
+      "beforeEach",
+      "afterEach"
+    ]
+  },
   "devDependencies": {
-    "code": "^1.4.0",
+    "chai": "^3.4.1",
     "jsdoc": "^3.3.0-beta3",
-    "lab": "^5.5.1",
+    "mocha": "^2.3.4",
     "sinon": "^1.14.1",
     "standard": "^5.4.1"
   },

--- a/test/events.js
+++ b/test/events.js
@@ -4,7 +4,7 @@ var assert = require('chai').assert
 var noop = require('101/noop')
 var sinon = require('sinon')
 
-require('loadenv')('cluster-man')
+require('loadenv')()
 var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {

--- a/test/events.js
+++ b/test/events.js
@@ -1,250 +1,244 @@
-'use strict';
+'use strict'
 
-var Lab = require('lab');
-var lab = exports.lab = Lab.script();
-var describe = lab.describe;
-var it = lab.it;
-var before = lab.before;
-var beforeEach = lab.beforeEach;
-var after = lab.after;
-var afterEach = lab.afterEach;
-var Code = require('code');
-var expect = Code.expect;
-var sinon = require('sinon');
-var noop = require('101/noop');
-var os = require('os');
-var debug = require('debug');
-var EventEmitter = require('events').EventEmitter;
+var Lab = require('lab')
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var beforeEach = lab.beforeEach
+var afterEach = lab.afterEach
+var Code = require('code')
+var expect = Code.expect
+var sinon = require('sinon')
+var noop = require('101/noop')
 
-require('loadenv')('cluster-man');
-var ClusterManager = require('../index.js');
+require('loadenv')('cluster-man')
+var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {
-  describe('events', function() {
-    var manager;
-    var infoSpy;
-    var numWorkers = 4;
+  describe('events', function () {
+    var manager
+    var infoSpy
+    var numWorkers = 4
 
     beforeEach(function (done) {
       manager = new ClusterManager({
         worker: noop,
         numWorkers: numWorkers
-      });
-      var workerId = 0;
-      sinon.stub(manager.cluster, 'fork', function() {
-        return { id: ++workerId };
-      });
-      infoSpy = sinon.spy(manager.log, 'info');
-      manager._startMaster();
-      done();
-    });
+      })
+      var workerId = 0
+      sinon.stub(manager.cluster, 'fork', function () {
+        return { id: ++workerId }
+      })
+      infoSpy = sinon.spy(manager.log, 'info')
+      manager._startMaster()
+      done()
+    })
 
     afterEach(function (done) {
-      manager.cluster.fork.restore();
-      manager.log.info.restore();
-      manager.cluster.removeAllListeners();
-      done();
-    });
+      manager.cluster.fork.restore()
+      manager.log.info.restore()
+      manager.cluster.removeAllListeners()
+      done()
+    })
 
     describe('fork', function () {
       it('should call `fork` when a worker is forked', function (done) {
-        var worker = manager.workers[0];
-        var spy = sinon.spy(manager, 'fork');
-        manager.cluster.emit('fork', worker);
-        expect(spy.calledWith(worker)).to.be.true();
-        manager.fork.restore();
-        done();
-      });
+        var worker = manager.workers[0]
+        var spy = sinon.spy(manager, 'fork')
+        manager.cluster.emit('fork', worker)
+        expect(spy.calledWith(worker)).to.be.true()
+        manager.fork.restore()
+        done()
+      })
 
       it('should indicate a worker fork in the logs', function (done) {
-        var worker = manager.workers[0];
-        manager.cluster.emit('fork', worker);
-        expect(infoSpy.calledWith('Worker forked: ' + worker.id)).to.be.true();
-        done();
-      });
-    }); // end 'fork'
-
+        var worker = manager.workers[0]
+        manager.cluster.emit('fork', worker)
+        expect(infoSpy.calledWith('Worker forked: ' + worker.id)).to.be.true()
+        done()
+      })
+    }) // end 'fork'
 
     describe('listening', function () {
       it('should call `listening` when a worker is listening', function (done) {
-        var worker = manager.workers[0];
-        var address = { address: '0.0.0.0', port: '9000' };
-        var spy = sinon.spy(manager, 'listening');
-        manager.cluster.emit('listening', worker, address);
-        expect(spy.calledWith(worker, address)).to.be.true();
-        manager.listening.restore();
-        done();
-      });
+        var worker = manager.workers[0]
+        var address = { address: '0.0.0.0', port: '9000' }
+        var spy = sinon.spy(manager, 'listening')
+        manager.cluster.emit('listening', worker, address)
+        expect(spy.calledWith(worker, address)).to.be.true()
+        manager.listening.restore()
+        done()
+      })
 
       it('should indicate a worker is listening in the logs', function (done) {
-        var worker = manager.workers[0];
-        var address = { address: '0.0.0.0', port: '9000' };
+        var worker = manager.workers[0]
+        var address = { address: '0.0.0.0', port: '9000' }
         var logLine = 'Worker listening: ' + worker.id +
-          ' on address ' + address.address + ':' + address.port;
+          ' on address ' + address.address + ':' + address.port
 
-        manager.cluster.emit('listening', worker, address);
-        expect(infoSpy.calledWith(logLine)).to.be.true();
-        done();
-      });
+        manager.cluster.emit('listening', worker, address)
+        expect(infoSpy.calledWith(logLine)).to.be.true()
+        done()
+      })
     }) // end 'listening'
 
     describe('exit', function () {
       it('should call `exit` when a worker exits', function (done) {
-        var worker = manager.workers[0];
-        var code = 1;
-        var signal = 'SIGBUS';
-        var spy = sinon.spy(manager, 'exit');
-        manager.cluster.emit('exit', worker, code, signal);
-        expect(spy.calledWith(worker, code, signal)).to.be.true();
-        manager.exit.restore();
-        done();
-      });
+        var worker = manager.workers[0]
+        var code = 1
+        var signal = 'SIGBUS'
+        var spy = sinon.spy(manager, 'exit')
+        manager.cluster.emit('exit', worker, code, signal)
+        expect(spy.calledWith(worker, code, signal)).to.be.true()
+        manager.exit.restore()
+        done()
+      })
 
       it('should indicate a worker exit in the logs', function (done) {
-        var worker = manager.workers[0];
-        var code = 0;
-        var signal = 'SIGINT';
+        var worker = manager.workers[0]
+        var code = 0
+        var signal = 'SIGINT'
         var logLine = 'Worker exited: ' + worker.id +
           ' -- with status: ' + code +
-          ' -- and signal: ' + signal;
+          ' -- and signal: ' + signal
 
-        manager.cluster.emit('exit', worker, code, signal);
-        expect(infoSpy.calledWith(logLine)).to.be.true();
-        done();
-      });
+        manager.cluster.emit('exit', worker, code, signal)
+        expect(infoSpy.calledWith(logLine)).to.be.true()
+        done()
+      })
 
       it('should remove a worker that exits', function (done) {
-        var worker = manager.workers[0];
-        var code = 0;
-        var signal = 'SIGINT';
-        manager.cluster.emit('exit', worker, code, signal);
-        expect(manager.workers.length).to.equal(numWorkers - 1);
+        var worker = manager.workers[0]
+        var code = 0
+        var signal = 'SIGINT'
+        manager.cluster.emit('exit', worker, code, signal)
+        expect(manager.workers.length).to.equal(numWorkers - 1)
         manager.workers.forEach(function (w) {
-          expect(w.id).to.not.equal(worker.id);
-        });
-        done();
-      });
+          expect(w.id).to.not.equal(worker.id)
+        })
+        done()
+      })
 
       it('should exit the master process if all workers exit', function (done) {
-        var stub = sinon.stub(manager, '_exitMaster');
-        var log = sinon.spy(manager.log, 'error');
+        var stub = sinon.stub(manager, '_exitMaster')
+        var log = sinon.spy(manager.log, 'error')
 
         // Need to indirectly iterate over the workers, since `manager.workers`
         // is modified by the 'exit' event handler
         manager.workers.map(function (worker) {
-          return worker;
+          return worker
         }).forEach(function (worker) {
-          manager.cluster.emit('exit', worker, 1, 'SIGINT');
-        });
+          manager.cluster.emit('exit', worker, 1, 'SIGINT')
+        })
 
         expect(stub.calledOnce)
-          .to.be.true();
+          .to.be.true()
         expect(stub.calledWithMatch({ message: 'All workers have died.' }))
-          .to.be.true();
+          .to.be.true()
         expect(log.calledWithMatch('Cluster fatal'))
-          .to.be.true();
+          .to.be.true()
 
-        manager._exitMaster.restore();
-        done();
-      });
-    }); // end 'exit'
+        manager._exitMaster.restore()
+        done()
+      })
+    }) // end 'exit'
 
     describe('online', function () {
       it('should call `online` when a worker goes online', function (done) {
-        var worker = manager.workers[0];
-        var spy = sinon.spy(manager, 'online');
-        manager.cluster.emit('online', worker);
-        expect(spy.calledWith(worker)).to.be.true();
-        manager.online.restore();
-        done();
-      });
+        var worker = manager.workers[0]
+        var spy = sinon.spy(manager, 'online')
+        manager.cluster.emit('online', worker)
+        expect(spy.calledWith(worker)).to.be.true()
+        manager.online.restore()
+        done()
+      })
 
       it('should indicate a worker has gone online in the logs', function (done) {
-        var worker = manager.workers[0];
-        manager.cluster.emit('online', worker);
-        expect(infoSpy.calledWith('Worker online: ' + worker.id)).to.be.true();
-        done();
-      });
-    }); // end 'online'
+        var worker = manager.workers[0]
+        manager.cluster.emit('online', worker)
+        expect(infoSpy.calledWith('Worker online: ' + worker.id)).to.be.true()
+        done()
+      })
+    }) // end 'online'
 
     describe('disconnect', function () {
       it('should call `disconnect` when a worker disconnects', function (done) {
-        var worker = manager.workers[0];
-        var spy = sinon.spy(manager, 'disconnect');
-        manager.cluster.emit('disconnect', worker);
-        expect(spy.calledWith(worker)).to.be.true();
-        manager.disconnect.restore();
-        done();
-      });
+        var worker = manager.workers[0]
+        var spy = sinon.spy(manager, 'disconnect')
+        manager.cluster.emit('disconnect', worker)
+        expect(spy.calledWith(worker)).to.be.true()
+        manager.disconnect.restore()
+        done()
+      })
 
       it('should indicate a worker has disconnected in the logs', function (done) {
-        var worker = manager.workers[0];
-        var logLine = 'Worker disconnected: ' + worker.id + ' -- killing';
-        manager.cluster.emit('disconnect', worker);
-        expect(infoSpy.calledWith(logLine)).to.be.true();
-        done();
-      });
-    }); // end 'disconnect'
-  }); // end 'events'
+        var worker = manager.workers[0]
+        var logLine = 'Worker disconnected: ' + worker.id + ' -- killing'
+        manager.cluster.emit('disconnect', worker)
+        expect(infoSpy.calledWith(logLine)).to.be.true()
+        done()
+      })
+    }) // end 'disconnect'
+  }) // end 'events'
 
   describe('masterError', function () {
-    var manager;
-    var errorObject = new Error('Unhandled Error');
+    var manager
+    var errorObject = new Error('Unhandled Error')
 
     beforeEach(function (done) {
       manager = new ClusterManager({
         worker: noop,
         master: function () {
-          throw errorObject;
+          throw errorObject
         },
         numWorkers: 1
-      });
-      sinon.stub(manager.cluster, 'fork').returns({ id: 'id' });
-      done();
-    });
+      })
+      sinon.stub(manager.cluster, 'fork').returns({ id: 'id' })
+      done()
+    })
 
     afterEach(function (done) {
-      manager.cluster.fork.restore();
-      done();
-    });
+      manager.cluster.fork.restore()
+      done()
+    })
 
     it('should call `masterError` on an uncaught master process error', function (done) {
       sinon.stub(manager, 'masterError', function (err) {
-        expect(err).to.equal(errorObject);
-        manager.masterError.restore();
-        done();
-      });
-      manager._startMaster();
-    });
+        expect(err).to.equal(errorObject)
+        manager.masterError.restore()
+        done()
+      })
+      manager._startMaster()
+    })
 
     it('should log uncaught errors on the master process', function (done) {
-      var spy = sinon.spy(manager.log, 'error');
+      var spy = sinon.spy(manager.log, 'error')
       sinon.stub(process, 'exit', function () {
-        expect(spy.calledTwice).to.be.true();
-        manager.log.error.restore();
-        process.exit.restore();
-        done();
-      });
-      manager._startMaster();
-    });
+        expect(spy.calledTwice).to.be.true()
+        manager.log.error.restore()
+        process.exit.restore()
+        done()
+      })
+      manager._startMaster()
+    })
 
     it('should exit the master process on uncaught errors', function (done) {
-      var stub = sinon.stub(manager, '_exitMaster', function (err) {
-        expect(err).to.equal(errorObject);
-        done();
-      });
-      manager._startMaster();
-    });
+      sinon.stub(manager, '_exitMaster', function (err) {
+        expect(err).to.equal(errorObject)
+        done()
+      })
+      manager._startMaster()
+    })
 
     it('should not exit the master process when `killOnError === false`', function (done) {
       var manager = new ClusterManager({
         worker: noop,
         killOnError: false
-      });
-      var stub = sinon.stub(manager, '_exitMaster');
-      manager.masterError(new Error('Error'));
-      expect(stub.callCount).to.equal(0);
-      done();
-    });
-  }); // end 'masterError'
-}); // end 'cluster-man'
+      })
+      var stub = sinon.stub(manager, '_exitMaster')
+      manager.masterError(new Error('Error'))
+      expect(stub.callCount).to.equal(0)
+      done()
+    })
+  }) // end 'masterError'
+}) // end 'cluster-man'

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,190 +1,168 @@
 'use strict'
 
-var Lab = require('lab')
-var lab = exports.lab = Lab.script()
-var describe = lab.describe
-var it = lab.it
-var beforeEach = lab.beforeEach
-var afterEach = lab.afterEach
-var Code = require('code')
-var expect = Code.expect
-var sinon = require('sinon')
+var EventEmitter = require('events').EventEmitter
+var assert = require('chai').assert
 var noop = require('101/noop')
 var os = require('os')
-var EventEmitter = require('events').EventEmitter
+var sinon = require('sinon')
 
 require('loadenv')('cluster-man')
 var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {
   describe('methods', function () {
-    describe('constructor', function (done) {
-      it('should throw an execption if worker function is missing', function (done) {
-        expect(function () {
-          return new ClusterManager()
-        }).to.throw(Error, 'Cluster must be provided with a worker closure.')
-        expect(function () {
-          return new ClusterManager({ master: function () {} })
-        }).to.throw(Error, 'Cluster must be provided with a worker closure.')
-        done()
+    describe('constructor', function () {
+      it('should throw an execption if worker function is missing', function () {
+        assert.throws(
+          function () { return new ClusterManager() },
+          Error,
+          'Cluster must be provided with a worker closure.'
+        )
+        assert.throws(
+          function () { return new ClusterManager({ master: function () {} }) },
+          Error,
+          'Cluster must be provided with a worker closure.'
+        )
       })
 
-      it('should correctly assign a worker function', function (done) {
+      it('should correctly assign a worker function', function () {
         var manager = new ClusterManager({ worker: noop })
-        expect(manager.options.worker).to.equal(noop)
-        done()
+        assert.equal(manager.options.worker, noop)
       })
 
-      it('should allow construction with only the worker function', function (done) {
+      it('should allow construction with only the worker function', function () {
         var manager = new ClusterManager(noop)
-        expect(manager.options.worker).to.equal(noop)
-        done()
+        assert.equal(manager.options.worker, noop)
       })
 
-      it('should default the master callback to noop', function (done) {
+      it('should default the master callback to noop', function () {
         var manager = new ClusterManager(function () { return 'worker' })
-        expect(manager.options.master).to.equal(noop)
-        done()
+        assert.equal(manager.options.master, noop)
       })
 
-      it('should set the master function based on passed options', function (done) {
+      it('should set the master function based on passed options', function () {
         var master = function () { return 'master' }
         var manager = new ClusterManager({
           worker: noop,
           master: master
         })
-        expect(manager.options.master).to.equal(master)
-        done()
+        assert.equal(manager.options.master, master)
       })
 
-      it('should use `CLUSTER_WORKERS` for `numWorkers`', function (done) {
+      it('should use `CLUSTER_WORKERS` for `numWorkers`', function () {
         var manager = new ClusterManager(noop)
-        expect(manager.options.numWorkers).to.equal(process.env.CLUSTER_WORKERS)
-        done()
+        assert.equal(manager.options.numWorkers, process.env.CLUSTER_WORKERS)
       })
 
-      it('should use # of CPUs for `numWorkers` if `CLUSTER_WORKERS` is missing', function (done) {
+      it('should use # of CPUs for `numWorkers` if `CLUSTER_WORKERS` is missing', function () {
         var envClusterWorkers = process.env.CLUSTER_WORKERS
         delete process.env.CLUSTER_WORKERS
         var manager = new ClusterManager(noop)
-        expect(manager.options.numWorkers).to.equal(os.cpus().length)
+        assert.equal(manager.options.numWorkers, os.cpus().length)
         process.env.CLUSTER_WORKERS = envClusterWorkers
-        done()
       })
 
-      it('should set `numWorkers` based on passed option', function (done) {
+      it('should set `numWorkers` based on passed option', function () {
         var workers = 1337
         var manager = new ClusterManager({ worker: noop, numWorkers: workers })
-        expect(manager.options.numWorkers).to.equal(workers)
-        done()
+        assert.equal(manager.options.numWorkers, workers)
       })
 
-      it('should use `CLUSTER_DEBUG` by default for debug scope', function (done) {
+      it('should use `CLUSTER_DEBUG` by default for debug scope', function () {
         var scope = process.env.CLUSTER_DEBUG
         var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
         var manager = new ClusterManager(noop)
-        expect(manager).to.exist()
-        expect(spy.calledWith('info', scope + ':info')).to.be.true()
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
-        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        assert.ok(manager)
+        sinon.assert.calledWith(spy, 'info', scope + ':info')
+        sinon.assert.calledWith(spy, 'warning', scope + ':warning')
+        sinon.assert.calledWith(spy, 'error', scope + ':error')
         ClusterManager.prototype._addLogger.restore()
-        done()
       })
 
-      it('should use `cluster-man` as a debug scope if `CLUSTER_DEBUG` is missing', function (done) {
+      it('should use `cluster-man` as a debug scope if `CLUSTER_DEBUG` is missing', function () {
         var envClusterDebug = process.env.CLUSTER_DEBUG
         delete process.env.CLUSTER_DEBUG
         var scope = 'cluster-man'
         var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
         var manager = new ClusterManager(noop)
-        expect(manager).to.exist()
-        expect(spy.calledWith('info', scope + ':info')).to.be.true()
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
-        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        assert.ok(manager)
+        sinon.assert.calledWith(spy, 'info', scope + ':info')
+        sinon.assert.calledWith(spy, 'warning', scope + ':warning')
+        sinon.assert.calledWith(spy, 'error', scope + ':error')
         process.env.CLUSTER_DEBUG = envClusterDebug
         ClusterManager.prototype._addLogger.restore()
-        done()
       })
 
-      it('should set debug scope based on passed options', function (done) {
+      it('should set debug scope based on passed options', function () {
         var scope = 'custom-scope'
         var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
         var manager = new ClusterManager({
           worker: noop,
           debugScope: scope
         })
-        expect(manager).to.exist()
-        expect(spy.calledWith('info', scope + ':info')).to.be.true()
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
-        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        assert.ok(manager)
+        sinon.assert.calledWith(spy, 'info', scope + ':info')
+        sinon.assert.calledWith(spy, 'warning', scope + ':warning')
+        sinon.assert.calledWith(spy, 'error', scope + ':error')
         ClusterManager.prototype._addLogger.restore()
-        done()
       })
 
-      it('should set `killOnError` to true by default', function (done) {
+      it('should set `killOnError` to true by default', function () {
         var manager = new ClusterManager(noop)
-        expect(manager.options.killOnError).to.be.true()
-        done()
+        assert.equal(manager.options.killOnError, true)
       })
 
-      it('should allow the user to set `killOnError` option', function (done) {
+      it('should allow the user to set `killOnError` option', function () {
         var manager = new ClusterManager({
           worker: noop,
           killOnError: false
         })
-        expect(manager.options.killOnError).to.be.false()
-        done()
+        assert.equal(manager.options.killOnError, false)
       })
 
-      it('should not allow non-function beforeExit option', function (done) {
+      it('should not allow non-function beforeExit option', function () {
         var manager = new ClusterManager({
           worker: noop,
           beforeExit: 'not a function'
         })
-        expect(manager.options.beforeExit).to.equal(noop)
-        done()
+        assert.equal(manager.options.beforeExit, noop)
       })
     }) // end 'constructor'
 
     describe('_addLogger', function () {
-      it('should add a logger to `this.log` with the appropriate name', function (done) {
+      it('should add a logger to `this.log` with the appropriate name', function () {
         var manager = new ClusterManager(noop)
         var name = 'example'
         manager._addLogger(name, name)
-        expect(manager.log[name]).to.exist()
-        expect(typeof manager.log[name]).to.equal('function')
-        done()
+        assert.ok(manager.log[name])
+        assert.isFunction(manager.log[name])
       })
     }) // end '_addLogger'
 
     describe('start', function () {
       var manager = new ClusterManager(noop)
-      beforeEach(function (done) {
+      beforeEach(function () {
         sinon.stub(manager, '_startMaster')
         sinon.stub(manager, '_startWorker')
-        done()
       })
 
-      afterEach(function (done) {
+      afterEach(function () {
         manager._startMaster.restore()
         manager._startWorker.restore()
-        done()
       })
 
-      it('should start master if in the master process', function (done) {
+      it('should start master if in the master process', function () {
         manager.cluster = { isMaster: true }
         manager.start()
-        expect(manager._startMaster.calledOnce).to.be.true()
-        expect(manager._startWorker.callCount).to.equal(0)
-        done()
+        sinon.assert.calledOnce(manager._startMaster)
+        sinon.assert.notCalled(manager._startWorker)
       })
 
-      it('should start a worker if in a worker process', function (done) {
+      it('should start a worker if in a worker process', function () {
         manager.cluster = { isMaster: false }
         manager.start()
-        expect(manager._startWorker.calledOnce).to.be.true()
-        expect(manager._startMaster.callCount).to.equal(0)
-        done()
+        sinon.assert.calledOnce(manager._startWorker)
+        sinon.assert.notCalled(manager._startMaster)
       })
     }) // end 'start'
 
@@ -193,7 +171,7 @@ describe('cluster-man', function () {
       var numWorkers = 3
       var master = function () { return 'master' }
 
-      beforeEach(function (done) {
+      beforeEach(function () {
         manager = new ClusterManager({
           master: master,
           worker: noop,
@@ -202,71 +180,77 @@ describe('cluster-man', function () {
         sinon.stub(manager, 'createWorker', function () {
           manager.workers.push({ id: 'id' })
         })
-        done()
       })
 
       it('should apply a domain to the cluster manager', function (done) {
+        sinon.stub(manager.options, 'master', function () {
+          assert.ok(manager.domain)
+          manager.options.master.restore()
+          done()
+        })
         manager._startMaster()
-        expect(manager.domain).to.exist()
-        done()
       })
 
       it('should bind the appropriate events on `cluster`', function (done) {
+        sinon.stub(manager.options, 'master', function () {
+          manager.options.master.restore()
+          assert.equal(spy.callCount, events.length)
+          events.forEach(function (name) {
+            sinon.assert.calledWith(spy, name)
+          })
+          done()
+        })
         var events = ['fork', 'online', 'listening', 'disconnect', 'exit']
         var spy = sinon.spy(manager.cluster, 'on')
         manager._startMaster()
-        expect(spy.callCount).to.equal(events.length)
-        events.forEach(function (name) {
-          expect(spy.calledWith(name)).to.be.true()
-        })
-        done()
       })
 
       it('should start the appropriate number of workers', function (done) {
+        sinon.stub(manager.options, 'master', function () {
+          assert.equal(manager.workers.length, numWorkers)
+          manager.options.master.restore()
+          done()
+        })
         manager._startMaster()
-        expect(manager.workers.length).to.equal(numWorkers)
-        done()
       })
 
       it('should call the master callback', function (done) {
-        var spy = sinon.spy(manager.options, 'master')
+        sinon.stub(manager.options, 'master', function () {
+          sinon.assert.calledOnce(manager.options.master)
+          manager.options.master.restore()
+          done()
+        })
         manager._startMaster()
-        expect(spy.calledOnce).to.be.true()
-        manager.options.master.restore()
-        done()
       })
 
       it('should not log a warning if number of workers specified', function (done) {
+        sinon.stub(manager.options, 'master', function () {
+          assert.notOk(spy.calledWith('Number of workers not specified, using default.'))
+          done()
+        })
         var spy = sinon.spy(manager.log, 'warning')
         manager._startMaster()
-        expect(spy.calledWith('Number of workers not specified, using default.'))
-          .to.be.false()
-        done()
       })
 
-      it('should log a warning if not given a number of workers', function (done) {
+      it('should log a warning if not given a number of workers', function () {
         var envClusterWorkers = process.env.CLUSTER_WORKERS
         delete process.env.CLUSTER_WORKERS
         var manager = new ClusterManager(noop)
         sinon.stub(manager, 'createWorker')
         var spy = sinon.spy(manager.log, 'warning')
         manager._startMaster()
-        expect(spy.calledWith('Number of workers not specified, using default.'))
-          .to.be.true()
+        sinon.assert.calledWith(spy, 'Number of workers not specified, using default.')
         process.env.CLUSTER_WORKERS = envClusterWorkers
-        done()
       })
     }) // end '_startMaster'
 
     describe('_exitMaster', function () {
-      beforeEach(function (done) {
+      beforeEach(function () {
         sinon.stub(process, 'exit')
-        done()
       })
 
-      afterEach(function (done) {
+      afterEach(function () {
         process.exit.restore()
-        done()
       })
 
       it('should execute the `beforeExit` callback', function (done) {
@@ -279,43 +263,40 @@ describe('cluster-man', function () {
         var spy = sinon.spy(manager.options, 'beforeExit')
         var err = new Error('Error')
         manager._exitMaster(err)
-        expect(spy.calledOnce).to.be.true()
-        expect(spy.calledWith(err)).to.be.true()
+        sinon.assert.calledOnce(spy)
+        sinon.assert.calledWith(spy, err)
         done()
       })
 
-      it('should exit the process with code 1 when given an error', function (done) {
+      it('should exit the process with code 1 when given an error', function () {
         var manager = new ClusterManager(noop)
         manager._exitMaster(new Error('error'))
-        expect(process.exit.calledOnce).to.be.true()
-        expect(process.exit.calledWith(1)).to.be.true()
-        done()
+        sinon.assert.calledOnce(process.exit)
+        sinon.assert.calledWith(process.exit, 1)
       })
 
-      it('should exit the process with code 0 when not given an error', function (done) {
+      it('should exit the process with code 0 when not given an error', function () {
         var manager = new ClusterManager(noop)
         manager._exitMaster()
-        expect(process.exit.calledOnce).to.be.true()
-        expect(process.exit.calledWith(0)).to.be.true()
-        done()
+        sinon.assert.calledOnce(process.exit)
+        sinon.assert.calledWith(process.exit, 0)
       })
     }) // end '_exitMaster'
 
     describe('_startWorker', function () {
-      it('should call the worker callback', function (done) {
+      it('should call the worker callback', function () {
         var manager = new ClusterManager(noop)
         var spy = sinon.spy(manager.options, 'worker')
         manager._startWorker()
-        expect(spy.calledWith(manager)).to.be.true()
+        sinon.assert.calledWith(spy, manager)
         manager.options.worker.restore()
-        done()
       })
     }) // end '_startWorker'
 
     describe('createWorker', function () {
       var manager
 
-      beforeEach(function (done) {
+      beforeEach(function () {
         manager = new ClusterManager(noop)
         var nextId = 0
         sinon.stub(manager.cluster, 'fork', function () {
@@ -326,60 +307,52 @@ describe('cluster-man', function () {
           }
           return worker
         })
-        done()
       })
 
-      afterEach(function (done) {
+      afterEach(function () {
         manager.cluster.fork.restore()
-        done()
       })
 
-      it('should fork a new worker', function (done) {
+      it('should fork a new worker', function () {
         manager.createWorker()
-        expect(manager.cluster.fork.calledOnce).to.be.true()
-        done()
+        sinon.assert.calledOnce(manager.cluster.fork)
       })
 
-      it('should set a domain for the worker', function (done) {
+      it('should set a domain for the worker', function () {
         var worker = manager.createWorker()
-        expect(worker.domain).to.exist()
-        done()
+        assert.ok(worker.domain)
       })
 
-      it('should kill a worker if there was an unhandled error', function (done) {
+      it('should kill a worker if there was an unhandled error', function () {
         var worker = manager.createWorker()
         var spy = sinon.spy(worker.process, 'kill')
         var error = new Error('error')
         worker.emit('error', error)
-        expect(spy.calledWith(1)).to.be.true()
+        sinon.assert.calledWith(spy, 1)
         worker.process.kill.restore()
-        done()
       })
 
-      it('it should indicate an unhandled worker error in the logs', function (done) {
+      it('it should indicate an unhandled worker error in the logs', function () {
         var worker = manager.createWorker()
         var spy = sinon.spy(manager.log, 'error')
         var error = new Error('error')
         worker.emit('error', error)
-        expect(spy.calledOnce).to.be.true()
+        sinon.assert.calledOnce(spy)
         manager.log.error.restore()
-        done()
       })
 
-      it('should add the worker to the set of workers', function (done) {
+      it('should add the worker to the set of workers', function () {
         var spy = sinon.spy(manager.workers, 'push')
         var worker = manager.createWorker()
-        expect(spy.calledWith(worker)).to.be.true()
+        sinon.assert.calledWith(spy, worker)
         manager.workers.push.restore()
-        done()
       })
 
-      it('should indicate a worker has been created in the logs', function (done) {
+      it('should indicate a worker has been created in the logs', function () {
         var spy = sinon.spy(manager.log, 'info')
         manager.createWorker()
-        expect(spy.calledOnce).to.be.true()
+        sinon.assert.calledOnce(spy)
         manager.log.info.restore()
-        done()
       })
     }) // end 'createWorker'
   })

--- a/test/methods.js
+++ b/test/methods.js
@@ -6,7 +6,7 @@ var noop = require('101/noop')
 var os = require('os')
 var sinon = require('sinon')
 
-require('loadenv')('cluster-man')
+require('loadenv')()
 var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,386 +1,386 @@
-'use strict';
+'use strict'
 
-var Lab = require('lab');
-var lab = exports.lab = Lab.script();
-var describe = lab.describe;
-var it = lab.it;
-var before = lab.before;
-var beforeEach = lab.beforeEach;
-var after = lab.after;
-var afterEach = lab.afterEach;
-var Code = require('code');
-var expect = Code.expect;
-var sinon = require('sinon');
-var noop = require('101/noop');
-var os = require('os');
-var debug = require('debug');
-var EventEmitter = require('events').EventEmitter;
+var Lab = require('lab')
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var beforeEach = lab.beforeEach
+var afterEach = lab.afterEach
+var Code = require('code')
+var expect = Code.expect
+var sinon = require('sinon')
+var noop = require('101/noop')
+var os = require('os')
+var EventEmitter = require('events').EventEmitter
 
-require('loadenv')('cluster-man');
-var ClusterManager = require('../index.js');
+require('loadenv')('cluster-man')
+var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {
   describe('methods', function () {
     describe('constructor', function (done) {
       it('should throw an execption if worker function is missing', function (done) {
-        expect(function() {
-          new ClusterManager();
-        }).to.throw(Error, 'Cluster must be provided with a worker closure.');
-        expect(function() {
-          new ClusterManager({ master: function() {} });
-        }).to.throw(Error, 'Cluster must be provided with a worker closure.');
-        done();
-      });
+        expect(function () {
+          return new ClusterManager()
+        }).to.throw(Error, 'Cluster must be provided with a worker closure.')
+        expect(function () {
+          return new ClusterManager({ master: function () {} })
+        }).to.throw(Error, 'Cluster must be provided with a worker closure.')
+        done()
+      })
 
       it('should correctly assign a worker function', function (done) {
-        var manager = new ClusterManager({ worker: noop });
-        expect(manager.options.worker).to.equal(noop);
-        done();
-      });
+        var manager = new ClusterManager({ worker: noop })
+        expect(manager.options.worker).to.equal(noop)
+        done()
+      })
 
       it('should allow construction with only the worker function', function (done) {
-        var manager = new ClusterManager(noop);
-        expect(manager.options.worker).to.equal(noop);
-        done();
-      });
+        var manager = new ClusterManager(noop)
+        expect(manager.options.worker).to.equal(noop)
+        done()
+      })
 
       it('should default the master callback to noop', function (done) {
-        var manager = new ClusterManager(function() { return 'worker'; });
-        expect(manager.options.master).to.equal(noop);
-        done();
-      });
+        var manager = new ClusterManager(function () { return 'worker' })
+        expect(manager.options.master).to.equal(noop)
+        done()
+      })
 
       it('should set the master function based on passed options', function (done) {
-        var master = function() { return 'master'; };
+        var master = function () { return 'master' }
         var manager = new ClusterManager({
           worker: noop,
           master: master
-        });
-        expect(manager.options.master).to.equal(master);
-        done();
-      });
+        })
+        expect(manager.options.master).to.equal(master)
+        done()
+      })
 
       it('should use `CLUSTER_WORKERS` for `numWorkers`', function (done) {
-        var manager = new ClusterManager(noop);
-        expect(manager.options.numWorkers).to.equal(process.env.CLUSTER_WORKERS);
-        done();
-      });
+        var manager = new ClusterManager(noop)
+        expect(manager.options.numWorkers).to.equal(process.env.CLUSTER_WORKERS)
+        done()
+      })
 
       it('should use # of CPUs for `numWorkers` if `CLUSTER_WORKERS` is missing', function (done) {
-        var envClusterWorkers = process.env.CLUSTER_WORKERS;
-        delete process.env.CLUSTER_WORKERS;
-        var manager = new ClusterManager(noop);
-        expect(manager.options.numWorkers).to.equal(os.cpus().length);
-        process.env.CLUSTER_WORKERS = envClusterWorkers;
-        done();
-      });
+        var envClusterWorkers = process.env.CLUSTER_WORKERS
+        delete process.env.CLUSTER_WORKERS
+        var manager = new ClusterManager(noop)
+        expect(manager.options.numWorkers).to.equal(os.cpus().length)
+        process.env.CLUSTER_WORKERS = envClusterWorkers
+        done()
+      })
 
       it('should set `numWorkers` based on passed option', function (done) {
-        var workers = 1337;
-        var manager = new ClusterManager({ worker: noop, numWorkers: workers });
-        expect(manager.options.numWorkers).to.equal(workers);
-        done();
-      });
+        var workers = 1337
+        var manager = new ClusterManager({ worker: noop, numWorkers: workers })
+        expect(manager.options.numWorkers).to.equal(workers)
+        done()
+      })
 
-      it('should use `CLUSTER_DEBUG` by default for debug scope', function(done) {
-        var scope = process.env.CLUSTER_DEBUG;
-        var spy = sinon.spy(ClusterManager.prototype, '_addLogger');
-        var manager = new ClusterManager(noop);
-        expect(spy.calledWith('info', scope + ':info')).to.be.true();
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true();
-        expect(spy.calledWith('error', scope + ':error')).to.be.true();
-        ClusterManager.prototype._addLogger.restore();
-        done();
-      });
+      it('should use `CLUSTER_DEBUG` by default for debug scope', function (done) {
+        var scope = process.env.CLUSTER_DEBUG
+        var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
+        var manager = new ClusterManager(noop)
+        expect(manager).to.exist()
+        expect(spy.calledWith('info', scope + ':info')).to.be.true()
+        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
+        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        ClusterManager.prototype._addLogger.restore()
+        done()
+      })
 
       it('should use `cluster-man` as a debug scope if `CLUSTER_DEBUG` is missing', function (done) {
-        var envClusterDebug = process.env.CLUSTER_DEBUG;
-        delete process.env.CLUSTER_DEBUG;
-        var scope = 'cluster-man';
-        var spy = sinon.spy(ClusterManager.prototype, '_addLogger');
-        var manager = new ClusterManager(noop);
-        expect(spy.calledWith('info', scope + ':info')).to.be.true();
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true();
-        expect(spy.calledWith('error', scope + ':error')).to.be.true();
-        process.env.CLUSTER_DEBUG = envClusterDebug;
-        ClusterManager.prototype._addLogger.restore();
-        done();
-      });
+        var envClusterDebug = process.env.CLUSTER_DEBUG
+        delete process.env.CLUSTER_DEBUG
+        var scope = 'cluster-man'
+        var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
+        var manager = new ClusterManager(noop)
+        expect(manager).to.exist()
+        expect(spy.calledWith('info', scope + ':info')).to.be.true()
+        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
+        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        process.env.CLUSTER_DEBUG = envClusterDebug
+        ClusterManager.prototype._addLogger.restore()
+        done()
+      })
 
       it('should set debug scope based on passed options', function (done) {
-        var scope = 'custom-scope';
-        var spy = sinon.spy(ClusterManager.prototype, '_addLogger');
+        var scope = 'custom-scope'
+        var spy = sinon.spy(ClusterManager.prototype, '_addLogger')
         var manager = new ClusterManager({
           worker: noop,
           debugScope: scope
-        });
-        expect(spy.calledWith('info', scope + ':info')).to.be.true();
-        expect(spy.calledWith('warning', scope + ':warning')).to.be.true();
-        expect(spy.calledWith('error', scope + ':error')).to.be.true();
-        ClusterManager.prototype._addLogger.restore();
-        done();
-      });
+        })
+        expect(manager).to.exist()
+        expect(spy.calledWith('info', scope + ':info')).to.be.true()
+        expect(spy.calledWith('warning', scope + ':warning')).to.be.true()
+        expect(spy.calledWith('error', scope + ':error')).to.be.true()
+        ClusterManager.prototype._addLogger.restore()
+        done()
+      })
 
       it('should set `killOnError` to true by default', function (done) {
-        var manager = new ClusterManager(noop);
-        expect(manager.options.killOnError).to.be.true();
-        done();
-      });
+        var manager = new ClusterManager(noop)
+        expect(manager.options.killOnError).to.be.true()
+        done()
+      })
 
       it('should allow the user to set `killOnError` option', function (done) {
         var manager = new ClusterManager({
           worker: noop,
           killOnError: false
-        });
-        expect(manager.options.killOnError).to.be.false();
-        done();
-      });
+        })
+        expect(manager.options.killOnError).to.be.false()
+        done()
+      })
 
-      it('should not allow non-function beforeExit option', function(done) {
+      it('should not allow non-function beforeExit option', function (done) {
         var manager = new ClusterManager({
           worker: noop,
           beforeExit: 'not a function'
-        });
-        expect(manager.options.beforeExit).to.equal(noop);
-        done();
-      });
-    }); // end 'constructor'
+        })
+        expect(manager.options.beforeExit).to.equal(noop)
+        done()
+      })
+    }) // end 'constructor'
 
     describe('_addLogger', function () {
       it('should add a logger to `this.log` with the appropriate name', function (done) {
-        var manager = new ClusterManager(noop);
-        var name = 'example';
-        manager._addLogger(name, name);
-        expect(manager.log[name]).to.exist();
-        expect(typeof manager.log[name]).to.equal('function');
-        done();
-      });
-    }); // end '_addLogger'
+        var manager = new ClusterManager(noop)
+        var name = 'example'
+        manager._addLogger(name, name)
+        expect(manager.log[name]).to.exist()
+        expect(typeof manager.log[name]).to.equal('function')
+        done()
+      })
+    }) // end '_addLogger'
 
-    describe('start', function() {
-      var manager = new ClusterManager(noop);
+    describe('start', function () {
+      var manager = new ClusterManager(noop)
       beforeEach(function (done) {
-        sinon.stub(manager, '_startMaster');
-        sinon.stub(manager, '_startWorker');
-        done();
-      });
+        sinon.stub(manager, '_startMaster')
+        sinon.stub(manager, '_startWorker')
+        done()
+      })
 
       afterEach(function (done) {
-        manager._startMaster.restore();
-        manager._startWorker.restore();
-        done();
-      });
+        manager._startMaster.restore()
+        manager._startWorker.restore()
+        done()
+      })
 
       it('should start master if in the master process', function (done) {
-        manager.cluster = { isMaster: true };
-        manager.start();
-        expect(manager._startMaster.calledOnce).to.be.true();
-        expect(manager._startWorker.callCount).to.equal(0);
-        done();
-      });
+        manager.cluster = { isMaster: true }
+        manager.start()
+        expect(manager._startMaster.calledOnce).to.be.true()
+        expect(manager._startWorker.callCount).to.equal(0)
+        done()
+      })
 
       it('should start a worker if in a worker process', function (done) {
-        manager.cluster = { isMaster: false };
-        manager.start();
-        expect(manager._startWorker.calledOnce).to.be.true();
-        expect(manager._startMaster.callCount).to.equal(0);
-        done();
-      });
-    }); // end 'start'
+        manager.cluster = { isMaster: false }
+        manager.start()
+        expect(manager._startWorker.calledOnce).to.be.true()
+        expect(manager._startMaster.callCount).to.equal(0)
+        done()
+      })
+    }) // end 'start'
 
     describe('_startMaster', function () {
-      var manager;
-      var numWorkers = 3;
-      var master = function() { return 'master'; };
+      var manager
+      var numWorkers = 3
+      var master = function () { return 'master' }
 
       beforeEach(function (done) {
         manager = new ClusterManager({
           master: master,
           worker: noop,
           numWorkers: numWorkers
-        });
+        })
         sinon.stub(manager, 'createWorker', function () {
-          manager.workers.push({ id: 'id' });
-        });
-        done();
-      });
+          manager.workers.push({ id: 'id' })
+        })
+        done()
+      })
 
       it('should apply a domain to the cluster manager', function (done) {
-        manager._startMaster();
-        expect(manager.domain).to.exist();
-        done();
-      });
+        manager._startMaster()
+        expect(manager.domain).to.exist()
+        done()
+      })
 
       it('should bind the appropriate events on `cluster`', function (done) {
-        var events = ['fork', 'online', 'listening', 'disconnect', 'exit'];
-        var spy = sinon.spy(manager.cluster, 'on');
-        manager._startMaster();
-        expect(spy.callCount).to.equal(events.length);
+        var events = ['fork', 'online', 'listening', 'disconnect', 'exit']
+        var spy = sinon.spy(manager.cluster, 'on')
+        manager._startMaster()
+        expect(spy.callCount).to.equal(events.length)
         events.forEach(function (name) {
-          expect(spy.calledWith(name)).to.be.true();
-        });
-        done();
-      });
+          expect(spy.calledWith(name)).to.be.true()
+        })
+        done()
+      })
 
       it('should start the appropriate number of workers', function (done) {
-        manager._startMaster();
-        expect(manager.workers.length).to.equal(numWorkers);
-        done();
-      });
+        manager._startMaster()
+        expect(manager.workers.length).to.equal(numWorkers)
+        done()
+      })
 
       it('should call the master callback', function (done) {
-        var spy = sinon.spy(manager.options, 'master');
-        manager._startMaster();
-        expect(spy.calledOnce).to.be.true();
-        manager.options.master.restore();
-        done();
-      });
+        var spy = sinon.spy(manager.options, 'master')
+        manager._startMaster()
+        expect(spy.calledOnce).to.be.true()
+        manager.options.master.restore()
+        done()
+      })
 
       it('should not log a warning if number of workers specified', function (done) {
-        var spy = sinon.spy(manager.log, 'warning');
-        manager._startMaster();
+        var spy = sinon.spy(manager.log, 'warning')
+        manager._startMaster()
         expect(spy.calledWith('Number of workers not specified, using default.'))
-          .to.be.false();
-        done();
-      });
+          .to.be.false()
+        done()
+      })
 
       it('should log a warning if not given a number of workers', function (done) {
-        var envClusterWorkers = process.env.CLUSTER_WORKERS;
-        delete process.env.CLUSTER_WORKERS;
-        var manager = new ClusterManager(noop);
-        sinon.stub(manager, 'createWorker');
-        var spy = sinon.spy(manager.log, 'warning');
-        manager._startMaster();
+        var envClusterWorkers = process.env.CLUSTER_WORKERS
+        delete process.env.CLUSTER_WORKERS
+        var manager = new ClusterManager(noop)
+        sinon.stub(manager, 'createWorker')
+        var spy = sinon.spy(manager.log, 'warning')
+        manager._startMaster()
         expect(spy.calledWith('Number of workers not specified, using default.'))
-          .to.be.true();
-        process.env.CLUSTER_WORKERS = envClusterWorkers;
-        done();
-      });
-    }); // end '_startMaster'
+          .to.be.true()
+        process.env.CLUSTER_WORKERS = envClusterWorkers
+        done()
+      })
+    }) // end '_startMaster'
 
-    describe('_exitMaster', function() {
+    describe('_exitMaster', function () {
       beforeEach(function (done) {
-        sinon.stub(process, 'exit');
-        done();
-      });
+        sinon.stub(process, 'exit')
+        done()
+      })
 
       afterEach(function (done) {
-        process.exit.restore();
-        done();
-      });
+        process.exit.restore()
+        done()
+      })
 
-      it('should execute the `beforeExit` callback', function(done) {
+      it('should execute the `beforeExit` callback', function (done) {
         var manager = new ClusterManager({
           worker: noop,
-          beforeExit: function(err, done) {
-            done();
+          beforeExit: function (err, done) { // eslint-disable-line handle-callback-err
+            done()
           }
-        });
-        var spy = sinon.spy(manager.options, 'beforeExit');
-        var err = new Error('Error');
-        manager._exitMaster(err);
-        expect(spy.calledOnce).to.be.true();
-        expect(spy.calledWith(err)).to.be.true();
-        done();
-      });
+        })
+        var spy = sinon.spy(manager.options, 'beforeExit')
+        var err = new Error('Error')
+        manager._exitMaster(err)
+        expect(spy.calledOnce).to.be.true()
+        expect(spy.calledWith(err)).to.be.true()
+        done()
+      })
 
-      it('should exit the process with code 1 when given an error', function(done) {
-        var manager = new ClusterManager(noop);
-        manager._exitMaster(new Error('error'));
-        expect(process.exit.calledOnce).to.be.true();
-        expect(process.exit.calledWith(1)).to.be.true();
-        done();
-      });
+      it('should exit the process with code 1 when given an error', function (done) {
+        var manager = new ClusterManager(noop)
+        manager._exitMaster(new Error('error'))
+        expect(process.exit.calledOnce).to.be.true()
+        expect(process.exit.calledWith(1)).to.be.true()
+        done()
+      })
 
       it('should exit the process with code 0 when not given an error', function (done) {
-        var manager = new ClusterManager(noop);
-        manager._exitMaster();
-        expect(process.exit.calledOnce).to.be.true();
-        expect(process.exit.calledWith(0)).to.be.true();
-        done();
-      });
-    }); // end '_exitMaster'
+        var manager = new ClusterManager(noop)
+        manager._exitMaster()
+        expect(process.exit.calledOnce).to.be.true()
+        expect(process.exit.calledWith(0)).to.be.true()
+        done()
+      })
+    }) // end '_exitMaster'
 
     describe('_startWorker', function () {
       it('should call the worker callback', function (done) {
-        var manager = new ClusterManager(noop);
-        var spy = sinon.spy(manager.options, 'worker');
-        manager._startWorker();
-        expect(spy.calledWith(manager)).to.be.true();
-        manager.options.worker.restore();
-        done();
-      });
-    }); // end '_startWorker'
+        var manager = new ClusterManager(noop)
+        var spy = sinon.spy(manager.options, 'worker')
+        manager._startWorker()
+        expect(spy.calledWith(manager)).to.be.true()
+        manager.options.worker.restore()
+        done()
+      })
+    }) // end '_startWorker'
 
     describe('createWorker', function () {
-      var manager;
+      var manager
 
       beforeEach(function (done) {
-        manager = new ClusterManager(noop);
-        var nextId = 0;
+        manager = new ClusterManager(noop)
+        var nextId = 0
         sinon.stub(manager.cluster, 'fork', function () {
-          var worker = new EventEmitter();
-          worker.id = ++nextId;
+          var worker = new EventEmitter()
+          worker.id = ++nextId
           worker.process = {
             kill: noop
-          };
-          return worker;
-        });
-        done();
-      });
+          }
+          return worker
+        })
+        done()
+      })
 
       afterEach(function (done) {
-        manager.cluster.fork.restore();
-        done();
-      });
+        manager.cluster.fork.restore()
+        done()
+      })
 
       it('should fork a new worker', function (done) {
-        manager.createWorker();
-        expect(manager.cluster.fork.calledOnce).to.be.true();
-        done();
-      });
+        manager.createWorker()
+        expect(manager.cluster.fork.calledOnce).to.be.true()
+        done()
+      })
 
       it('should set a domain for the worker', function (done) {
-        var worker = manager.createWorker();
-        expect(worker.domain).to.exist();
-        done();
-      });
+        var worker = manager.createWorker()
+        expect(worker.domain).to.exist()
+        done()
+      })
 
       it('should kill a worker if there was an unhandled error', function (done) {
-        var worker = manager.createWorker();
-        var spy = sinon.spy(worker.process, 'kill');
-        var error = new Error('error');
-        worker.emit('error', error);
-        expect(spy.calledWith(1)).to.be.true();
-        worker.process.kill.restore();
-        done();
-      });
+        var worker = manager.createWorker()
+        var spy = sinon.spy(worker.process, 'kill')
+        var error = new Error('error')
+        worker.emit('error', error)
+        expect(spy.calledWith(1)).to.be.true()
+        worker.process.kill.restore()
+        done()
+      })
 
       it('it should indicate an unhandled worker error in the logs', function (done) {
-        var worker = manager.createWorker();
-        var spy = sinon.spy(manager.log, 'error');
-        var error = new Error('error');
-        worker.emit('error', error);
-        expect(spy.calledOnce).to.be.true();
-        manager.log.error.restore();
-        done();
-      });
+        var worker = manager.createWorker()
+        var spy = sinon.spy(manager.log, 'error')
+        var error = new Error('error')
+        worker.emit('error', error)
+        expect(spy.calledOnce).to.be.true()
+        manager.log.error.restore()
+        done()
+      })
 
       it('should add the worker to the set of workers', function (done) {
-        var spy = sinon.spy(manager.workers, 'push');
-        var worker = manager.createWorker();
-        expect(spy.calledWith(worker)).to.be.true();
-        manager.workers.push.restore();
-        done();
-      });
+        var spy = sinon.spy(manager.workers, 'push')
+        var worker = manager.createWorker()
+        expect(spy.calledWith(worker)).to.be.true()
+        manager.workers.push.restore()
+        done()
+      })
 
       it('should indicate a worker has been created in the logs', function (done) {
-        var spy = sinon.spy(manager.log, 'info');
-        manager.createWorker();
-        expect(spy.calledOnce).to.be.true();
-        manager.log.info.restore();
-        done();
-      });
-    }); // end 'createWorker'
-  });
-});
+        var spy = sinon.spy(manager.log, 'info')
+        manager.createWorker()
+        expect(spy.calledOnce).to.be.true()
+        manager.log.info.restore()
+        done()
+      })
+    }) // end 'createWorker'
+  })
+})

--- a/test/module.js
+++ b/test/module.js
@@ -1,21 +1,15 @@
 'use strict'
 
-var Lab = require('lab')
-var lab = exports.lab = Lab.script()
-var describe = lab.describe
-var it = lab.it
-var Code = require('code')
-var expect = Code.expect
+var assert = require('chai').assert
 
 require('loadenv')('cluster-man')
 var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {
   describe('module', function () {
-    it('should expose the ClusterManager class', function (done) {
-      expect(ClusterManager).to.exist()
-      expect(typeof ClusterManager).to.equal('function')
-      done()
+    it('should expose the ClusterManager class', function () {
+      assert.ok(ClusterManager)
+      assert.isFunction(ClusterManager)
     })
   }) // end 'module'
 }) // end 'cluster-man'

--- a/test/module.js
+++ b/test/module.js
@@ -2,7 +2,7 @@
 
 var assert = require('chai').assert
 
-require('loadenv')('cluster-man')
+require('loadenv')()
 var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {

--- a/test/module.js
+++ b/test/module.js
@@ -1,30 +1,21 @@
-'use strict';
+'use strict'
 
-var Lab = require('lab');
-var lab = exports.lab = Lab.script();
-var describe = lab.describe;
-var it = lab.it;
-var before = lab.before;
-var beforeEach = lab.beforeEach;
-var after = lab.after;
-var afterEach = lab.afterEach;
-var Code = require('code');
-var expect = Code.expect;
-var sinon = require('sinon');
-var noop = require('101/noop');
-var os = require('os');
-var debug = require('debug');
-var EventEmitter = require('events').EventEmitter;
+var Lab = require('lab')
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var Code = require('code')
+var expect = Code.expect
 
-require('loadenv')('cluster-man');
-var ClusterManager = require('../index.js');
+require('loadenv')('cluster-man')
+var ClusterManager = require('../index.js')
 
 describe('cluster-man', function () {
   describe('module', function () {
     it('should expose the ClusterManager class', function (done) {
-      expect(ClusterManager).to.exist();
-      expect(typeof ClusterManager).to.equal('function');
-      done();
-    });
-  }); // end 'module'
-}); // end 'cluster-man'
+      expect(ClusterManager).to.exist()
+      expect(typeof ClusterManager).to.equal('function')
+      done()
+    })
+  }) // end 'module'
+}) // end 'cluster-man'


### PR DESCRIPTION
Most of this PR leaves things unchanged. However, there are a couple things that are drastically different:
- `_startMaster` now runs the `master` code asynchronously (see [here](https://github.com/Runnable/cluster-man/compare/update-dependencies#diff-168726dbe96b3ce427e7fedce31bb0bcR180)); this ensures the errors thrown are caught by domains. this was being hidden by `lab` during testing (as `lab` heavily uses domains)
- with the above change, some tests had to be adjusted to expect the `master` function to be called asynchronously (nothing crazy, just adjustments)

Less exciting things:
- `standard` has been applied to the repo. removed all semicolons and formatted the code
- `lab` and `code` have been replace with `mocha` and `chai` (the latest versions of the former require node 4.x now)
- tests that were able to be made synchronous are now synchronous
- testing on travis now includes node `4.2` and `5` (allowing failures on `5`) and uses the container testing environment
